### PR TITLE
fix syntax error in gradle script

### DIFF
--- a/vsmCiCd-init.gradle
+++ b/vsmCiCd-init.gradle
@@ -1,7 +1,7 @@
 initscript {
     repositories {
         maven {
-            url '<https://plugins.gradle.org/m2/'>
+            url '<https://plugins.gradle.org/m2/>'
         }
     }
 


### PR DESCRIPTION
this fixes a syntax error during gradle usage of plugin, corresponding error:

```
FAILURE: Build failed with an exception.
* Where:
Initialization script '/vsmCiCd-init.gradle' line: 4
* What went wrong:
Could not compile initialization script '/vsmCiCd-init.gradle'.
> startup failed:
  initialization script '/vsmCiCd-init.gradle': 4: expecting '}', found '<https://plugins.gradle.org/m2/' @ line 4, column 17.
                 url '<https://plugins.gradle.org/m2/'>
                     ^
  1 error
```